### PR TITLE
Harmonize discid compat with lates python-discid

### DIFF
--- a/libdiscid/compat/discid.py
+++ b/libdiscid/compat/discid.py
@@ -188,6 +188,16 @@ class Disc:
             return None
         return value if value != "" else None
 
+    @property
+    def cddb_query_string(self) -> str:
+        assert self._disc is not None
+        cddb_query = [
+            self.freedb_id,
+            self.last_track_num,
+            *self._disc.track_offsets,
+            libdiscid.sectors_to_seconds(self.sectors)
+        ]
+        return " ".join(map(str, cddb_query))
 
 # functions defined in discid
 get_default_device = libdiscid.default_device

--- a/libdiscid/compat/discid.py
+++ b/libdiscid/compat/discid.py
@@ -25,6 +25,7 @@ a replacement for python-discid. It provides an interface compatible with
 python-discid version 1.0.2.
 """
 
+from collections.abc import Iterable, Sequence
 import libdiscid
 import operator
 import functools
@@ -35,23 +36,6 @@ _INVERSE_FEATURES = {
     libdiscid.FEATURES_MAPPING[libdiscid.FEATURE_MCN]: libdiscid.FEATURE_MCN,
     libdiscid.FEATURES_MAPPING[libdiscid.FEATURE_ISRC]: libdiscid.FEATURE_ISRC,
 }
-
-
-class _NoneHelper:
-    def __getattr__(self, name):
-        if name in (
-            "id",
-            "freedb_id",
-            "submission_url",
-            "toc",
-            "first_track",
-            "last_track",
-            "sectors",
-            "mcn",
-        ):
-            return None
-
-        return super().__getattr__(name)
 
 
 def _decode(string, encoding=None):
@@ -75,20 +59,20 @@ class TOCError(Exception):
 
 # classes defined in discid
 class Track:
-    def __init__(self, disc, number):
-        self.disc = disc
+    def __init__(self, disc: libdiscid.DiscId, number: int):
+        self._disc = disc
         self.number = number
 
     def __str__(self):
         return str(self.number)
 
     @property
-    def offset(self):
-        return self.disc.track_offsets[self.number - self.disc.first_track]
+    def offset(self) -> int:
+        return self._disc.track_offsets[self.number - self._disc.first_track]
 
     @property
     def sectors(self):
-        return self.disc.track_lengths[self.number - self.disc.first_track]
+        return self._disc.track_lengths[self.number - self._disc.first_track]
 
     length = sectors
 
@@ -99,7 +83,7 @@ class Track:
     @property
     def isrc(self):
         try:
-            value = self.disc.track_isrcs[self.number - self.disc.first_track]
+            value = self._disc.track_isrcs[self.number - self._disc.first_track]
         except NotImplementedError:
             return None
         return value if value != "" else None
@@ -107,11 +91,16 @@ class Track:
 
 class Disc:
     def __init__(self):
-        self.disc = _NoneHelper()
-        self.tracks = []
+        self._disc: libdiscid.DiscId | None = None
+        self.tracks: list[Track] = []
 
-    def read(self, device, features=[]):
-        self.disc = libdiscid.read(
+    def read(
+        self, device: str | bytes | None = None, features: Iterable[str] | None = None
+    ) -> bool:
+        if features is None:
+            features = []
+
+        self._disc = libdiscid.read(
             device,
             functools.reduce(
                 operator.or_,
@@ -123,66 +112,73 @@ class Disc:
                 0,
             ),
         )
-        self.tracks = [
-            Track(self.disc, numb)
-            for numb in range(self.disc.first_track, self.disc.last_track + 1)
-        ]
+        self._populate_tracks()
         return True
 
-    def put(self, first, last, disc_sectors, track_offsets):
+    def put(
+        self, first: int, last: int, disc_sectors: int, track_offsets: Sequence[int]
+    ) -> bool:
         try:
-            self.disc = libdiscid.put(first, last, disc_sectors, track_offsets)
+            self._disc = libdiscid.put(first, last, disc_sectors, list(track_offsets))
         except DiscError as disc_error:
             raise TOCError(str(disc_error))
 
-        self.tracks = [
-            Track(self.disc, num)
-            for num in range(self.disc.first_track, self.disc.last_track + 1)
-        ]
+        self._populate_tracks()
         return True
 
-    @property
-    def id(self):
-        return self.disc.id
+    def _populate_tracks(self):
+        assert self._disc is not None
+        self.tracks = [
+            Track(self._disc, num)
+            for num in range(self._disc.first_track, self._disc.last_track + 1)
+        ]
 
     @property
-    def freedb_id(self):
-        return self.disc.freedb_id
+    def id(self) -> str:
+        assert self._disc is not None
+        return self._disc.id
 
     @property
-    def submission_url(self):
-        return self.disc.submission_url
+    def freedb_id(self) -> str:
+        assert self._disc is not None
+        return self._disc.freedb_id
 
     @property
-    def toc_string(self):
-        return self.disc.toc
+    def submission_url(self) -> str | None:
+        assert self._disc is not None
+        return self._disc.submission_url
 
     @property
-    def first_track_num(self):
-        return self.disc.first_track
+    def toc_string(self) -> str | None:
+        assert self._disc is not None
+        return self._disc.toc
 
     @property
-    def last_track_num(self):
-        return self.disc.last_track
+    def first_track_num(self) -> int:
+        assert self._disc is not None
+        return self._disc.first_track
 
     @property
-    def sectors(self):
-        return self.disc.sectors
+    def last_track_num(self) -> int:
+        assert self._disc is not None
+        return self._disc.last_track
+
+    @property
+    def sectors(self) -> int:
+        assert self._disc is not None
+        return self._disc.sectors
 
     length = sectors
 
     @property
-    def seconds(self):
-        return (
-            libdiscid.sectors_to_seconds(self.sectors)
-            if self.sectors is not None
-            else None
-        )
+    def seconds(self) -> int:
+        return libdiscid.sectors_to_seconds(self.sectors)
 
     @property
-    def mcn(self):
+    def mcn(self) -> str | None:
+        assert self._disc is not None
         try:
-            value = self.disc.mcn
+            value = self._disc.mcn
         except NotImplementedError:
             return None
         return value if value != "" else None
@@ -192,16 +188,15 @@ class Disc:
 get_default_device = libdiscid.default_device
 
 
-def read(device=None, features=[]):
+def read(device: str | bytes | None = None, features: Iterable[str] | None = None) -> Disc:
     disc = Disc()
-    disc.read(
-        _decode(device) if device is not None else None,
-        map(lambda feature: _decode(feature, "ascii"), features),
-    )
+    if features:
+        features = map(lambda feature: _decode(feature, "ascii"), features)
+    disc.read(_decode(device) if device is not None else None, features)
     return disc
 
 
-def put(first, last, disc_sectors, track_offsets):
+def put(first: int, last: int, disc_sectors: int, track_offsets: Sequence[int]) -> Disc:
     disc = Disc()
     disc.put(first, last, disc_sectors, track_offsets)
     return disc

--- a/libdiscid/compat/discid.py
+++ b/libdiscid/compat/discid.py
@@ -164,6 +164,11 @@ class Disc:
         return self._disc.last_track
 
     @property
+    def pregap(self) -> int:
+        assert self._disc is not None
+        return self._disc.pregap
+
+    @property
     def sectors(self) -> int:
         assert self._disc is not None
         return self._disc.sectors

--- a/libdiscid/tests/test_compat_discid.py
+++ b/libdiscid/tests/test_compat_discid.py
@@ -102,6 +102,13 @@ class TestCompatDiscID(unittest.TestCase):
         self.assertEqual(disc.pregap, testdata.offsets[0])
         self.assertEqual(disc.sectors, testdata.sectors)
         self.assertEqual(disc.seconds, testdata.seconds)
+        expected_cddb_query = [
+            testdata.freedb_id,
+            testdata.last,
+            *testdata.offsets,
+            testdata.seconds,
+        ]
+        self.assertEqual(disc.cddb_query_string, " ".join(map(str, expected_cddb_query)))
 
         self.assertEqual(len(disc.tracks), len(testdata.offsets))
         for track, offset, sec in zip(

--- a/libdiscid/tests/test_compat_discid.py
+++ b/libdiscid/tests/test_compat_discid.py
@@ -99,6 +99,7 @@ class TestCompatDiscID(unittest.TestCase):
         self.assertEqual(disc.toc_string, testdata.toc)
         self.assertEqual(disc.first_track_num, testdata.first)
         self.assertEqual(disc.last_track_num, testdata.last)
+        self.assertEqual(disc.pregap, testdata.offsets[0])
         self.assertEqual(disc.sectors, testdata.sectors)
         self.assertEqual(disc.seconds, testdata.seconds)
 

--- a/libdiscid/tests/test_compat_discid.py
+++ b/libdiscid/tests/test_compat_discid.py
@@ -38,16 +38,24 @@ class TestCompatDiscID(unittest.TestCase):
     def test_features_implementes(self):
         self.assertIsNotNone(discid.FEATURES_IMPLEMENTED)
 
-    def test_empty_is_none(self):
+    def test_unitialized_assertion_fails(self):
         disc = discid.Disc()
-        self.assertIsNone(disc.id)
-        self.assertIsNone(disc.freedb_id)
-        self.assertIsNone(disc.submission_url)
-        self.assertIsNone(disc.toc_string)
-        self.assertIsNone(disc.first_track_num)
-        self.assertIsNone(disc.last_track_num)
-        self.assertIsNone(disc.sectors)
-        self.assertIsNone(disc.seconds)
+        with self.assertRaises(AssertionError):
+            disc.id
+        with self.assertRaises(AssertionError):
+            disc.freedb_id
+        with self.assertRaises(AssertionError):
+            disc.submission_url
+        with self.assertRaises(AssertionError):
+            disc.toc_string
+        with self.assertRaises(AssertionError):
+            disc.first_track_num
+        with self.assertRaises(AssertionError):
+            disc.last_track_num
+        with self.assertRaises(AssertionError):
+            disc.sectors
+        with self.assertRaises(AssertionError):
+            disc.seconds
         self.assertEqual(len(disc.tracks), 0)
 
     @unittest.skipIf(


### PR DESCRIPTION
This harmonizes the `compat.discid` implementation to be fully compatible with latest [python-discid](https://github.com/metabrainz/python-discid) 1.4. It includes the following changes:

1. Add type hints to all public facing code, with type hints being identical to python-discid
2. Adjust the implementation that it does not all the return values are optional and can be `None`. This wasn't the case since python-discid v1.1.0, which expects `read` or `put` being called before any of the accessors can be used.
3. Added the `Disc.pregap` property, present since python-discid 1.4.0. This is similar to the `pregap` propery python-libdiscid has.
4. 3. Added the `Disc.cddb_query_string` property, present since python-discid 1.3.0