### PR TITLE
DEFAULT_DEVICE was set in libdiscid.__all__, but is not actually defined

### DIFF
--- a/libdiscid/__init__.py
+++ b/libdiscid/__init__.py
@@ -320,7 +320,6 @@ __all__ = (
     "FEATURE_READ",
     "FEATURE_MCN",
     "FEATURE_ISRC",
-    "DEFAULT_DEVICE",
     "DiscId",
     "DiscError",
 )


### PR DESCRIPTION
Remove DEFAULT_DEVICE from `__all__`. This is a leftover of a constant once defined (removed in 3117ecafae19b09a21846cea917d24f9d7be0ba8).